### PR TITLE
Add in a heartbeat sequence as well as refactor current code into separate routines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+default: run
+
+
+build:
+	go build ./cmd/main.go
+
+run:
+	go run ./cmd/main.go
+
+# lint:
+# 	go fmt
+
+clean:
+	go clean
+
+test:
+	go test

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"go-bot/pkg/discord"
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 func main() {
 	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGINT)
+	go func() {
+		<-interrupt
+		fmt.Println("\nBot Terminated By User")
+		os.Exit(0)
+	}()
 	discord.Initialize()
 }

--- a/pkg/discord/heartbeat.go
+++ b/pkg/discord/heartbeat.go
@@ -1,0 +1,35 @@
+package discord
+
+import (
+	"encoding/json"
+	"time"
+)
+
+var heartbeatBody = []byte(`{
+	"op": 1,
+	"d": null
+}`)
+
+// Heartbeat ...
+func (c *Client) heartbeat(interval int) {
+	defer c.waitGroup.Done()
+	for {
+		if c.heartbeatAck == true {
+			c.heartbeatAck = false
+			c.SendEvent(heartbeatBody)
+			time.Sleep(time.Duration(interval) * time.Millisecond)
+		} else {
+			panic("Heartbeat Not Acknowledged")
+		}
+	}
+}
+
+// ExtractInterval ...
+func ExtractInterval(body json.RawMessage) (int, error) {
+	res := HeartBeatRes{}
+	err := json.Unmarshal(body, &res)
+	if err != nil {
+		return 0, err
+	}
+	return res.Interval, nil
+}

--- a/pkg/discord/listen.go
+++ b/pkg/discord/listen.go
@@ -1,0 +1,33 @@
+package discord
+
+import "fmt"
+
+func (c *Client) listening() {
+	defer c.waitGroup.Done()
+	for {
+		newEvent := c.ReadEvent()
+		// fmt.Printf("\n\nReceived new event: %v \n\n", newEvent)
+		c.handleEvent(newEvent)
+		PrintEvent(newEvent)
+	}
+}
+
+func (c *Client) handleEvent(eve Event) {
+
+	// We can fill out these OP codes as we find things we need.
+	switch eve.OP {
+	case 0:
+		fmt.Println("\n\nOP code 0 received")
+	case 1:
+		fmt.Println("\n\nOP code 1 received")
+	case 2:
+		fmt.Println("\n\nOP code 2 received")
+	case 3:
+		fmt.Println("\n\nOP code 3 received")
+	case 11:
+		fmt.Println("\n\nOP code 11 received")
+		c.heartbeatAck = true
+	default:
+		fmt.Println("\n\nAn unsupported OP code was received")
+	}
+}

--- a/pkg/discord/types.go
+++ b/pkg/discord/types.go
@@ -1,0 +1,34 @@
+package discord
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+// Event ...
+type Event struct {
+	T  string          `json:"t"`
+	S  int             `json:"s"`
+	OP int             `json:"op"`
+	D  json.RawMessage `json:"d"`
+}
+
+// URL ...
+type URL struct {
+	URL string `json:"url"`
+}
+
+// HeartBeatRes ...
+type HeartBeatRes struct {
+	Interval int `json:"heartbeat_interval"`
+}
+
+// Client represents the state data and connection to discord.
+type Client struct {
+	conn         *websocket.Conn
+	waitGroup    *sync.WaitGroup
+	connLock     *sync.Mutex
+	heartbeatAck bool
+}


### PR DESCRIPTION
The previous functionality of reaching a ready state with discord was maintained while there is now a constant heartbeat check. Both routines use the same read/write conn so some locks were needed to be implemented to prevent two routines trying to use the same socket at the same time. It is not insanely robust right now but it is functional (afaik).